### PR TITLE
Updated check for submission being already tagged

### DIFF
--- a/to_catch_a_spammer.py
+++ b/to_catch_a_spammer.py
@@ -84,8 +84,8 @@ if __name__ == "__main__":
             tagged = False
 
             for comment in submission.comments.list():
-                comment_text = comment.body
-                if "*Beep boop*" in comment_text:
+                comment_author = comment.author
+                if comment_author == reddit.user.me():
                     print("This submission has already been tagged.")
                     tagged = True
 


### PR DESCRIPTION
Since we only post once per thread, instead of looking for "*Beep Boop" we can search for our bots username in the comment. 